### PR TITLE
ci: bump node20 actions for node24 cutover

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -30,7 +30,7 @@ jobs:
       has_pages: ${{ steps.has-pages.outputs.has_pages }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set 'has_pages' to output
         id: has-pages
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Cache collected data
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: static/data/repositories.json
           key: ${{ runner.os }}-cache-repositories-${{ hashFiles('scripts/collect.py', 'static/data/repositories.json') }}
@@ -78,7 +78,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         if: env.use_cache != 'true'
         with:
           python-version: '3.9'
@@ -99,7 +99,7 @@ jobs:
           echo "Generated successfully!"
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "22"
           cache: yarn
@@ -107,13 +107,13 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         if: github.ref == 'refs/heads/main' && steps.has-pages.outputs.has_pages == 'true'
         with: # Automatically inject pathPrefix in your Gatsby configuration file.
           static_site_generator: gatsby
 
       - name: Restore cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             public
@@ -145,4 +145,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
GitHub forces `using: node20` JS actions to Node 24 on 2026-06-02. Bumping the six affected pins in `.github/workflows/build_and_publish.yml` to the lowest tag that declares `using: node24`.

- `actions/checkout`: v4 → v5.0.1
- `actions/cache`: v4 → v5.0.5
- `actions/setup-python`: v5 → v6.2.0
- `actions/setup-node`: v4 → v5.0.0
- `actions/configure-pages`: v5 → v6.0.0
- `actions/deploy-pages`: v4 → v5.0.0