### PR TITLE
Update upload-pages-artifact

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -129,7 +129,7 @@ jobs:
         run: yarn run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         if: github.ref == 'refs/heads/main' && steps.has-pages.outputs.has_pages == 'true'
         with:
           path: ./public


### PR DESCRIPTION
The version in use wasn't pinning actions/upload-artifact, so it wasn't allowed.