### PR TITLE
Fix two bugs in the repo collector

### DIFF
--- a/scripts/collect.py
+++ b/scripts/collect.py
@@ -193,7 +193,7 @@ def collect_repositories(
                     private=gh_repo.private,
                     fork=gh_repo.fork,
                     archived=gh_repo.archived,
-                    disabled=gh_repo.archived,
+                    disabled=gh_repo.raw_data.get("disabled", False),
                     allow_forking=gh_repo.allow_forking,
                     is_template=gh_repo.is_template,
                     main_language=gh_repo.language,
@@ -205,7 +205,7 @@ def collect_repositories(
                 ))
     g.close()
     all_repos = list({rp.id: rp for rp in all_repos}.values())  # remove duplicates
-    all_repos.sort(key=lambda rp: gh_repo.id)  # sort by id
+    all_repos.sort(key=lambda rp: rp.id)  # sort by id
     return all_repos
 
 


### PR DESCRIPTION
The disabled field was being filled in with the archived value, so every repo reported the same thing for both. It now reads the real value from the GitHub API response.

The sort was using the wrong variable for its key, so every repo got the same key and the list never actually got sorted. It now sorts by repo id as intended.

Neither affects what the website shows.

Note: the sort fix will produce a large diff on static/data/repositories.json the next time the collector runs, since the list has never actually been sorted.